### PR TITLE
Add modify(data:)

### DIFF
--- a/Sources/PostgresStORM.swift
+++ b/Sources/PostgresStORM.swift
@@ -47,7 +47,11 @@ open class PostgresStORM: StORM, StORMProtocol {
 	private func printDebug(_ statement: String, _ params: [String]) {
 		if StORMdebug { LogFile.debug("StORM Debug: \(statement) : \(params.joined(separator: ", "))", logFile: "./StORMlog.txt") }
 	}
-
+	
+	open func modify(data: [(String, Any)]) -> [(String, Any)] {
+		return data
+	}
+	
 	// Internal function which executes statements, with parameter binding
 	// Returns raw result
 	@discardableResult
@@ -147,10 +151,10 @@ open class PostgresStORM: StORM, StORMProtocol {
 	open func save() throws {
 		do {
 			if keyIsEmpty() {
-				try insert(asData(1))
+				try insert(modify(data: asData(1)))
 			} else {
 				let (idname, idval) = firstAsKey()
-				try update(data: asData(1), idName: idname, idValue: idval)
+				try update(data: modify(data: asData(1)), idName: idname, idValue: idval)
 			}
 		} catch {
 			LogFile.error("Error: \(error)", logFile: "./StORMlog.txt")
@@ -167,11 +171,11 @@ open class PostgresStORM: StORM, StORMProtocol {
 	open func save(set: (_ id: Any)->Void) throws {
 		do {
 			if keyIsEmpty() {
-				let setId = try insert(asData(1))
+				let setId = try insert(modify(data: asData(1)))
 				set(setId)
 			} else {
 				let (idname, idval) = firstAsKey()
-				try update(data: asData(1), idName: idname, idValue: idval)
+				try update(data: modify(data: asData(1)), idName: idname, idValue: idval)
 			}
 		} catch {
 			LogFile.error("Error: \(error)", logFile: "./StORMlog.txt")
@@ -183,7 +187,7 @@ open class PostgresStORM: StORM, StORMProtocol {
 	
 	override open func create() throws {
 		do {
-			try insert(asData())
+			try insert(modify(data: asData()))
 		} catch {
 			LogFile.error("Error: \(error)", logFile: "./StORMlog.txt")
 			throw StORMError.error("\(error)")
@@ -253,5 +257,3 @@ open class PostgresStORM: StORM, StORMProtocol {
 	}
 	
 }
-
-


### PR DESCRIPTION
This adds and implements `open func modify(data: [(String, Any)]) -> [(String, Any)]` to the `PostgresStORM` class.
The intent of this addition is to allow base classes to optionally change the data sent to the database. For example, I am using it to properly handle the `Date` class as follows:
```swift
override func modify(data: [(String, Any)]) -> [(String, Any)] {
	var dat = data
	for (i, v) in dat.enumerated() {
		if let d = v.1 as? Date {
			dat[i] = (v.0, d.timestamptz)
		}
	}
	
	return dat
}
```
Where `timestamptz` returns the date formatted as a PostgreSQL `timestamp with time zone` string.