### PR TITLE
PostgresStORM.find() - added `cursor` parameter + unittest improvements

### DIFF
--- a/Sources/Convenience.swift
+++ b/Sources/Convenience.swift
@@ -61,7 +61,9 @@ extension PostgresStORM {
 	}
 
 	/// Performs a find on mathing column name/value pairs.
-	public func find(_ data: [(String, Any)]) throws {
+	/// An optional `cursor:StORMCursor` object can be supplied to determine pagination through a larger result set.
+	/// For example, `try find([("username","joe")])` will find all rows that have a username equal to "joe"
+	public func find(_ data: [(String, Any)], cursor: StORMCursor = StORMCursor()) throws {
 		let (idname, _) = firstAsKey()
 
 		var paramsString = [String]()
@@ -72,7 +74,7 @@ extension PostgresStORM {
 		}
 
 		do {
-			try select(whereclause: set.joined(separator: " AND "), params: paramsString, orderby: [idname])
+			try select(whereclause: set.joined(separator: " AND "), params: paramsString, orderby: [idname], cursor: cursor)
 		} catch {
 			LogFile.error("Error: \(error)", logFile: "./StORMlog.txt")
 			throw error
@@ -82,7 +84,9 @@ extension PostgresStORM {
 
 
 	/// Performs a find on mathing column name/value pairs.
-	public func find(_ data: [String: Any]) throws {
+	/// An optional `cursor:StORMCursor` object can be supplied to determine pagination through a larger result set.
+	/// For example, `try find(["username": "joe"])` will find all rows that have a username equal to "joe"
+	public func find(_ data: [String: Any], cursor: StORMCursor = StORMCursor()) throws {
 		let (idname, _) = firstAsKey()
 
 		var paramsString = [String]()
@@ -95,7 +99,7 @@ extension PostgresStORM {
 		}
 
 		do {
-			try select(whereclause: set.joined(separator: " AND "), params: paramsString, orderby: [idname])
+			try select(whereclause: set.joined(separator: " AND "), params: paramsString, orderby: [idname], cursor: cursor)
 		} catch {
 			LogFile.error("Error: \(error)", logFile: "./StORMlog.txt")
 			throw error

--- a/Tests/PostgresStORMTests/PostgresStORMTests.swift
+++ b/Tests/PostgresStORMTests/PostgresStORMTests.swift
@@ -303,6 +303,19 @@ class PostgresStORMTests: XCTestCase {
 				XCTFail("Find error: \(obj.error.string())")
 			}
 		}
+
+		// Doing the same `find` should now return rows limited by the provided cursor limit
+		do {
+			let obj = User()
+			do {
+				let cursor = StORMCursor(limit: 150, offset: 0)
+				try obj.find(["lastname": "Ashpool"], cursor: cursor)
+				XCTAssertEqual(obj.results.rows.count, cursor.limit, "Object should have found the all the rows just inserted. Limited by the provided cursor limit.")
+				XCTAssertEqual(obj.results.cursorData.totalRecords, 200, "Object should have found the all the rows just inserted")
+			} catch {
+				XCTFail("Find error: \(obj.error.string())")
+			}
+		}
 	}
 	
 	/* =============================================================================================

--- a/Tests/PostgresStORMTests/PostgresStORMTests.swift
+++ b/Tests/PostgresStORMTests/PostgresStORMTests.swift
@@ -251,13 +251,57 @@ class PostgresStORMTests: XCTestCase {
 	Find
 	============================================================================================= */
 	func testFind() {
-		let obj = User()
-
+		// Ensure table is empty
 		do {
-			try obj.find([("firstname", "Joe")])
-			//print("Find Record:  \(obj.id), \(obj.firstname), \(obj.lastname), \(obj.email)")
-		} catch {
-			XCTFail("Find error: \(obj.error.string())")
+			let obj = User()
+			let tableName = obj.table()
+			_ = try? obj.sql("DELETE FROM \(tableName)", params: [])
+		}
+
+		// Doing a `find` with an empty table should yield zero results
+		do {
+			let obj = User()
+			do {
+				try obj.find([("lastname", "Ashpool")])
+				XCTAssertEqual(obj.results.rows.count, 0)
+				XCTAssertEqual(obj.results.cursorData.totalRecords, 0)
+			} catch {
+				XCTFail("Find error: \(obj.error.string())")
+			}
+		}
+
+		// Insert more rows than the StORMCursor().limit
+		for i in 0..<200 {
+			let obj = User()
+			obj.firstname = "Tessier\(i)"
+			obj.lastname = "Ashpool"
+			do {
+				try obj.save { id in obj.id = id as! Int }
+			} catch {
+				XCTFail(String(describing: error))
+			}
+		}
+		for i in 0..<10 {
+			let obj = User()
+			obj.firstname = "Molly\(i)"
+			do {
+				try obj.save { id in obj.id = id as! Int }
+			} catch {
+				XCTFail(String(describing: error))
+			}
+		}
+
+		// Doing the same `find` should now return rows
+		do {
+			let obj = User()
+			do {
+				try obj.find([("lastname", "Ashpool")])
+				let cursorLimit: Int = StORMCursor().limit
+				XCTAssertEqual(obj.results.rows.count, cursorLimit, "Object should have found the all the rows just inserted. Limited by the default cursor limit.")
+				XCTAssertEqual(obj.results.cursorData.totalRecords, 200, "Object should have found the all the rows just inserted")
+			} catch {
+				XCTFail("Find error: \(obj.error.string())")
+			}
 		}
 	}
 	


### PR DESCRIPTION
Today when using `find()`, I was expecting 123 rows, but got only 50 rows. So I investigated what was going on.

It turned out to be, because `find()` is invoking `select()` without any `cursor` parameter, thus the default `StORMCursor.limit = 50` is being used.

I have added an optional `cursor` parameter to `find()`, so that it's possible to control pagination.

I have improved the test code for `find()` and `findAll()`.
