### PR TITLE
URL encoding for connection string

### DIFF
--- a/Sources/PostgresConnect.swift
+++ b/Sources/PostgresConnect.swift
@@ -43,7 +43,7 @@ open class PostgresConnect: StORMConnect {
 
 	// Connection String
 	private func connectionString() -> String {
-		let conn = "postgresql://\(credentials.username):\(credentials.password)@\(credentials.host):\(credentials.port)/\(database)"
+		let conn = "postgresql://\(credentials.username.stringByEncodingURL):\(credentials.password.stringByEncodingURL)@\(credentials.host.stringByEncodingURL):\(credentials.port)/\(database.stringByEncodingURL)"
 		if StORMdebug { LogFile.info("Postgres conn: \(conn)", logFile: "./StORMlog.txt") }
 		return conn
 	}


### PR DESCRIPTION
Fixes connection failure when using special characters in usernames/passwords, etc.